### PR TITLE
Default branch

### DIFF
--- a/.github/workflows/terrateam.yaml
+++ b/.github/workflows/terrateam.yaml
@@ -5,7 +5,7 @@
  #
  # Looking for the Terrateam configuration file? .terrateam/config.yml.
  #
- # See https://terrateam.io/docs/configuration for details
+ # See https://docs.terrateam.io/configuration/overview for details
  ##########################################################################
  name: 'Terrateam Workflow'
  on:

--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -1,2 +1,3 @@
 access_control:
-  enabled: false
+  enabled: true
+  terrateam_config_update: []

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
Access control is sourced from default branch.

Disable in default branch and enable in feature branch.  In the feature branch,
set `terrateam_config_update` to `[]`, disabling all changes.  If access control
is sourced from the default branch, performing a plan will be allowed.