### PR TITLE
Access control disabled does not execute

### DIFF
--- a/.github/workflows/terrateam.yaml
+++ b/.github/workflows/terrateam.yaml
@@ -5,7 +5,7 @@
  #
  # Looking for the Terrateam configuration file? .terrateam/config.yml.
  #
- # See https://terrateam.io/docs/configuration for details
+ # See https://docs.terrateam.io/configuration/overview for details
  ##########################################################################
  name: 'Terrateam Workflow'
  on:

--- a/.terrateam/config.yml~
+++ b/.terrateam/config.yml~
@@ -3,6 +3,3 @@ access_control:
   policies:
     - tag_query: ''
       plan: []
-
-indexer:
-    enabled: true

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
Access control does not run when disabled.

Disable access control in the default branch and disable the ability to plan,
try to perform a plan and it will pass.