### PR TITLE
Enabling access control in OSS gives message

### DIFF
--- a/.github/workflows/terrateam.yaml
+++ b/.github/workflows/terrateam.yaml
@@ -5,7 +5,7 @@
  #
  # Looking for the Terrateam configuration file? .terrateam/config.yml.
  #
- # See https://terrateam.io/docs/configuration for details
+ # See https://docs.terrateam.io/configuration/overview for details
  ##########################################################################
  name: 'Terrateam Workflow'
  on:

--- a/.terrateam/config.yml~
+++ b/.terrateam/config.yml~
@@ -1,4 +1,5 @@
 access_control:
-  enabled: false
+  enabled: true
+  terrateam_config_update: []
 engine:
   name: tofu

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
OSS users should get a message informing them that access control is functionality they have.