### PR TITLE
Validate that if performing an explicity apply is required for automerge to work, when `require_explicit_apply` is set to true

### DIFF
--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -2,7 +2,7 @@ automerge:
   enabled: true
   delete_branch: true 
   merge_strategy: rebase
-  require_explicit_apply: true
+  require_explicit_apply: true 
 
 engine:
   name: tofu


### PR DESCRIPTION
Validate that if performing an explicity apply is required for automerge to work, when `require_explicit_apply` is set to true