### PR TITLE
A plan by a user not not matching any policy in terrateam_config_update policy list is rejected

### DIFF
--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -1,5 +1,4 @@
 access_control:
   enabled: true
-  terrateam_config_update: []
 engine:
   name: tofu

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
Terrateam repo config updated with user not in the policy gets rejected.