### PR TITLE
Default branch

### DIFF
--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -1,4 +1,7 @@
 access_control:
-  enabled: false
+  enabled: true
+  terrateam_config_update: []
 engine:
   name: tofu
+indexer:
+  enabled: true

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
Access control is sourced from default branch.

Disable in default branch and enable in feature branch.  In the feature branch,
set `terrateam_config_update` to `[]`, disabling all changes.  If access control
is sourced from the default branch, performing a plan will be allowed.