### PR TITLE
Access control disabled does not execute

### DIFF
--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -5,3 +5,5 @@ access_control:
     tag_query: ''
 engine:
   name: tofu
+indexer:
+  enabled: true

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
Access control does not run when disabled.

Disable access control in the default branch and disable the ability to plan,
try to perform a plan and it will pass.