### PR TITLE
Referance mismatch does not fail

### DIFF
--- a/.terrateam/config.yml
+++ b/.terrateam/config.yml
@@ -1,2 +1,3 @@
 engine:
   name: tofu
+

--- a/tf/tf.tf
+++ b/tf/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}

--- a/tf2/tf.tf
+++ b/tf2/tf.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}


### PR DESCRIPTION
When there is a reference mismatch, another work manifest is automatically
executed with the updated references.